### PR TITLE
[DEV-5169] Use causely ai namespace label in causely bot

### DIFF
--- a/causely_notification/field_registry.py
+++ b/causely_notification/field_registry.py
@@ -23,7 +23,7 @@ FIELD_DEFINITIONS = {
     "severity": {"type": "direct", "path": "severity"},
     "entity.type": {"type": "direct", "path": "entity.type"},
     "labels.k8s.cluster.name": {"type": "map_path", "path": "labels", "map_key": "k8s.cluster.name"},
-    "labels.k8s.namespace.name": {"type": "map_path", "path": "labels", "map_key": "k8s.namespace.name"},
+    "labels.k8s.namespace.name": {"type": "map_path", "path": "labels", "map_key": "causely.ai/namespace"},
     "impactsSLO": {"type": "computed", "func": "compute_impact_slo"},
     "name": {"type": "direct", "path": "name"},
 }

--- a/tests/test_field_registry.py
+++ b/tests/test_field_registry.py
@@ -88,6 +88,20 @@ class TestFieldRegistry(unittest.TestCase):
             ),
         )
 
+    def test_get_map_value_namespace(self):
+        # labels exists but requested key (k8s.cluster.name) is not in it -> None
+        payload = {
+            "entity": {"type": "host"},
+            "labels": {"other_key": "other_value", "causely.ai/namespace": "namespace1"},
+            "name": "test-entity",
+        }
+        self.assertEqual(
+            self.field_registry.get_field_value(
+                payload, "labels.k8s.namespace.name",
+            ),
+                "namespace1",
+        )
+
     def test_get_computed_field_value(self):
         # Testing a computed field
         payload = {


### PR DESCRIPTION
Use the causely.ai/namespace label to match in payloads instead of k8s.namespace.name